### PR TITLE
ZIP archive-like images name when downloading manually

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -309,7 +309,7 @@ function download_image( info, tab ) {
     var img_url_orig = img_url.replace( /:\w*$/, '' ) + ':orig',
         // filename = get_filename_from_image_url( img_url_orig );
         extension = get_extension_from_image_url( img_url_orig ),
-        filename = tab.url.replace( /^https?:\/\/(?:mobile\.)?twitter\.com\/([^\/]+)\/status(?:es)?\/(\d+).*$/, '$1-$2' ),
+        filename = info.linkUrl.replace( /^https?:\/\/(?:mobile\.)?twitter\.com\/([^\/]+)\/status(?:es)?\/(\d+)\/photo\/(\d+).*$/, '$1-$2-img$3' ),
         filename = filename + '.' + extension;
     
     img_url_orig = get_formatted_img_url( img_url_orig );

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -193,6 +193,21 @@ function get_filename_from_image_url( img_url ) {
 } // end of get_filename_from_image_url()
 
 
+function get_extension_from_image_url( img_url ) {
+    if ( ! /:\w*$/.test( img_url ) ) {
+        return null;
+    }
+    
+    if ( ! img_url.match( /^.+\/([^\/.]+)\.(\w+):(\w+)$/ ) ) {
+        return null;
+    }
+    
+    var ext = RegExp.$2;
+    
+    return ext;
+} // end of get_extension_from_image_url()
+
+
 function set_values( name_value_map, callback ) {
     return new Promise( function ( resolve, reject ) {
         chrome.storage.local.set( name_value_map, function () {
@@ -292,7 +307,10 @@ function download_image( info, tab ) {
     img_url = normalize_img_url( img_url );
     
     var img_url_orig = img_url.replace( /:\w*$/, '' ) + ':orig',
-        filename = get_filename_from_image_url( img_url_orig );
+        // filename = get_filename_from_image_url( img_url_orig );
+        extension = get_extension_from_image_url( img_url_orig ),
+        filename = tab.url.replace( /^https?:\/\/(?:mobile\.)?twitter\.com\/([^\/]+)\/status(?:es)?\/(\d+).*$/, '$1-$2' ),
+        filename = filename + '.' + extension;
     
     img_url_orig = get_formatted_img_url( img_url_orig );
     

--- a/src/js/twOpenOriginalImage.user.js
+++ b/src/js/twOpenOriginalImage.user.js
@@ -2470,7 +2470,7 @@ function initialize( user_options ) {
         } // end of mouse_is_on_scrollbar()
         
         
-        function add_images_to_page( img_urls, parent, options ) {
+        function add_images_to_page( img_urls, tweet_url, parent, options ) {
             if ( ! options ) {
                 options = {};
             }
@@ -2484,6 +2484,8 @@ function initialize( user_options ) {
             
             var remaining_images_counter = 0;
             
+            let filename_prefix = tweet_url.replace( /^https?:\/\/(?:mobile\.)?twitter\.com\/([^\/]+)\/status(?:es)?\/(\d+).*$/, '$1-$2' );
+            
             img_urls.forEach( function ( img_url, index ) {
                 var img = import_node( img_template, target_document ),
                     link = import_node( link_template, target_document ),
@@ -2495,6 +2497,8 @@ function initialize( user_options ) {
                         mouse_click = object_extender( MouseClick ).init( download_link );
                     
                     download_link.href = img_url;
+                    let img_extension = get_img_extension( img_url );
+                    let img_filename = filename_prefix + '-img' + ( index + 1 ) + '.' + img_extension;
                     
                     if ( is_bookmarklet() ) {
                         mouse_click.start( function ( event ) {
@@ -2520,7 +2524,7 @@ function initialize( user_options ) {
                             
                             fetch( download_link.href )
                             .then( response => response.blob() )
-                            .then( blob => save_blob( download_link.download, blob ) );
+                            .then( blob => save_blob( img_filename, blob ) );
                             
                             return false;
                         } );
@@ -2737,7 +2741,7 @@ function initialize( user_options ) {
                 image_overlay_header.style.borderBottom = 'solid 1px silver';
             }
             
-            add_images_to_page( img_urls, image_overlay_image_container, {
+            add_images_to_page( img_urls, tweet_url, image_overlay_image_container, {
                 start_img_url : start_img_url
             ,   callback : function () {
                     if ( image_overlay_container.style.display == 'none' ) {
@@ -3271,7 +3275,7 @@ function initialize( user_options ) {
                     body.appendChild( header );
                 }
                 
-                add_images_to_page( img_urls, body, { document : child_document } );
+                add_images_to_page( img_urls, tweet_url, body, { document : child_document } );
                 
                 child_window.focus();
                 

--- a/src/js/twOpenOriginalImage.user.js
+++ b/src/js/twOpenOriginalImage.user.js
@@ -2487,9 +2487,8 @@ function initialize( user_options ) {
                 target_document = d;
             }
             
-            var remaining_images_counter = 0;
-            
-            let filename_prefix = get_filename_prefix(tweet_url);
+            var remaining_images_counter = 0,
+                filename_prefix = get_filename_prefix(tweet_url);
             
             img_urls.forEach( function ( img_url, index ) {
                 var img = import_node( img_template, target_document ),
@@ -2499,11 +2498,11 @@ function initialize( user_options ) {
                 if ( OPTIONS.DOWNLOAD_HELPER_SCRIPT_IS_VALID ) {
                     var download_link = create_download_link( img_url, target_document ),
                         download_link_container = import_node( download_link_container_template, target_document ),
-                        mouse_click = object_extender( MouseClick ).init( download_link );
+                        mouse_click = object_extender( MouseClick ).init( download_link ),
+                        img_extension = get_img_extension( img_url ),
+                        img_filename = filename_prefix + '-img' + ( index + 1 ) + '.' + img_extension;
                     
                     download_link.href = img_url;
-                    let img_extension = get_img_extension( img_url );
-                    let img_filename = filename_prefix + '-img' + ( index + 1 ) + '.' + img_extension;
                     
                     if ( is_bookmarklet() ) {
                         mouse_click.start( function ( event ) {

--- a/src/js/twOpenOriginalImage.user.js
+++ b/src/js/twOpenOriginalImage.user.js
@@ -1079,6 +1079,11 @@ function save_base64( filename, base64, mimetype ) {
 } // end of save_base64()
 
 
+function get_filename_prefix( tweet_url ) {
+    return tweet_url.replace( /^https?:\/\/(?:mobile\.)?twitter\.com\/([^\/]+)\/status(?:es)?\/(\d+).*$/, '$1-$2' );
+} // end of get_filename_prefix()
+
+
 function download_zip( tweet_info_json ) {
     var tweet_info,
         tweet_url,
@@ -1108,7 +1113,7 @@ function download_zip( tweet_info_json ) {
     }
     
     var zip = new JSZip(),
-        filename_prefix = tweet_url.replace( /^https?:\/\/(?:mobile\.)?twitter\.com\/([^\/]+)\/status(?:es)?\/(\d+).*$/, '$1-$2' );
+        filename_prefix = get_filename_prefix(tweet_url);
     
     timestamp_ms = ( timestamp_ms ) ? timestamp_ms : get_timestamp_ms_from_tweet_url( tweet_url );
     
@@ -2484,7 +2489,7 @@ function initialize( user_options ) {
             
             var remaining_images_counter = 0;
             
-            let filename_prefix = tweet_url.replace( /^https?:\/\/(?:mobile\.)?twitter\.com\/([^\/]+)\/status(?:es)?\/(\d+).*$/, '$1-$2' );
+            let filename_prefix = get_filename_prefix(tweet_url);
             
             img_urls.forEach( function ( img_url, index ) {
                 var img = import_node( img_template, target_document ),


### PR DESCRIPTION
With this PR, the download file name in the viewer and the right click context menu is similar to the image file name in the zip archive.

I feel like this is the natural extension of the file naming scheme but if this is not on your plan, feel free to close the PR.