### PR TITLE
Apply GM_config - Userscript version can set options without editing the script

### DIFF
--- a/src/js/twOpenOriginalImage.user.js
+++ b/src/js/twOpenOriginalImage.user.js
@@ -1910,7 +1910,6 @@ function initialize( user_options ) {
                 header_style.fontSize = '16px';
                 header_style.margin = '0 0 8px';
                 header_style.padding = '6px 8px 2px';
-                header_style.height = '16px';
                 header_style.fontFamily = 'Arial, "ヒラギノ角ゴ Pro W3", "Hiragino Kaku Gothic Pro", Osaka, メイリオ, Meiryo, "ＭＳ Ｐゴシック", "MS PGothic", sans-serif';
                 header_style.lineHeight = '0.8';
                 


### PR DESCRIPTION
[GM_config](https://github.com/sizzlemctwizzle/GM_config) is a simple GUI solution for userscript settings.
It provides a simple GUI setting page and save the data to userscript manager storage(via GM_setValue/GM_getValue).
This PR applies GM_config to `twOpenOriginalImage.user.js` to make setting functionality available.

I didn't bump up the script version because there might be some points you want to change.
Thank you.

***

[GM_config](https://github.com/sizzlemctwizzle/GM_config)はユーザスクリプトを設定するための簡単なGUIソリューションです。
それは簡単なGUI設定ページを提供し、その値をGM_getValueとGM_setValueを利用してTampermonkeyのストレージに保存します。
このPRは`twOpenOriginalImage.user.js`にGM_configを適用させ、ユーザスクリプトバージョンでも設定機能を利用できるようにします。

修正する部分がある可能性がありますので、バージョンはアップしていません。
ありがとうございます。